### PR TITLE
french

### DIFF
--- a/test/nonreg/Bug14.cl
+++ b/test/nonreg/Bug14.cl
@@ -27,8 +27,8 @@ P0 :: PISTE(missile1 = M0)
 
 // bug du 16/2/99
 
-// la variable lastl n'est pas prot�g�e contre le gc.
-// La cellule est recup�r�e par l'appel gc()
+// la variable lastl n'est pas protégée contre le gc.
+// La cellule est recupérée par l'appel gc()
 // et on a n'importe quoi quand on cherche a imprimer en fin de procedure.
 [bug3(n:integer)
  -> let lastl:list<tuple(integer,integer)> := list<tuple(integer,integer)>(),

--- a/test/nonreg/Bug3.cl
+++ b/test/nonreg/Bug3.cl
@@ -83,8 +83,8 @@ Tab[x:INT,y:INT] : integer := 0
 ; gestion de la table de hash pour les array[integer].
 ; si tu traces le system.graph de ancetre[], on decouvre que entre le
 ; noeud 34  et 17, il y a un probleme dans le graphe de relation...
-; ainsi ancetre n'est pu du tout aliment� comme il faut et il est
-; impossible de d�piler la solution : depile-solution()
+; ainsi ancetre n'est pu du tout alimenté comme il faut et il est
+; impossible de dépiler la solution : depile-solution()
 
 ; Le probleme consiste a savoir si il est possible
 ; de reduire tous les nombres a la valeur 1 en leur
@@ -114,7 +114,7 @@ rule3()	-> (if (( val mod 2 ) = 0) val := val / 2
 ; valeur[i] = 2 already explored
 valeur[n:integer] : integer := 0
 
-; indice du noeud le plus faible non explor�
+; indice du noeud le plus faible non exploré
 lower:integer := 1    
 
 // DEBUG si pas hash table ca marche.


### PR DESCRIPTION
@ycaseau 

test/nonreg/Bug6.cl

Lines 143 and 144 have characters unable contextually to be determined.

This is opened as a Draft owing to the foregoing; were you to provide a fix then it can be implemented in this pull.

Separately would you accept another pull converting the line endings from DOS format?

update

> test/nonreg/Bug6.cl
> 
> Lines 143 and 144 have characters unable contextually to be determined.

As the lines are commented out marking this Ready for review.